### PR TITLE
Fix: Null Access error when requesting a non-existant route.

### DIFF
--- a/tests/TestPath.hx
+++ b/tests/TestPath.hx
@@ -1,9 +1,18 @@
+import haxe.display.Display.Package;
 import haxe.Http;
 
 class TestPath {
 	public static function main() {
 		trace("Starting Path Test");
 		var app = new weblink.Weblink();
+
+		//simply reimplement the route not found to confirm that doing this doesn't kill everything.
+		app.set_fnRouteNotFound(function(request, response){
+			response.status = 404;
+			response.send("Error 404, Route Not found.");
+		});
+
+
 		var data = haxe.io.Bytes.ofString(Std.string(Std.random(10 * 1000))).toHex();
 		app.get("/path", function(request, response) {
 			response.send(data);
@@ -39,7 +48,6 @@ class TestPath {
 					throw "/notapath should return a Status 404.";
 				}
 			}
-
 			app.close();
 		});
 

--- a/tests/TestPath.hx
+++ b/tests/TestPath.hx
@@ -6,7 +6,7 @@ class TestPath {
 		var app = new weblink.Weblink();
 
 		//simply reimplement the route not found to confirm that doing this doesn't kill everything.
-		app.set_fnRouteNotFound(function(request, response){
+		app.set_pathNotFound(function(request, response){
 			response.status = 404;
 			response.send("Error 404, Route Not found.");
 		});

--- a/tests/TestPath.hx
+++ b/tests/TestPath.hx
@@ -1,4 +1,3 @@
-import haxe.display.Display.Package;
 import haxe.Http;
 
 class TestPath {

--- a/tests/TestPath.hx
+++ b/tests/TestPath.hx
@@ -31,6 +31,15 @@ class TestPath {
 			var response = Http.requestUrl("http://localhost:2000/another");
 			if (response != data)
 				throw "/another: post response data does not match: " + response + " data: " + data;
+
+			try {
+				var nopath = Http.requestUrl("http://localhost:2000/notapath");
+			} catch (e) {
+				if(e.message != "Http Error #404"){
+					throw "/notapath should return a Status 404.";
+				}
+			}
+
 			app.close();
 		});
 

--- a/weblink/Weblink.hx
+++ b/weblink/Weblink.hx
@@ -1,8 +1,5 @@
 package weblink;
 
-import haxe.http.HttpStatus;
-import haxe.http.HttpMethod;
-import weblink._internal.Mime;
 import weblink._internal.Server;
 
 using haxe.io.Path;

--- a/weblink/Weblink.hx
+++ b/weblink/Weblink.hx
@@ -1,5 +1,6 @@
 package weblink;
 
+import haxe.Constraints.Function;
 import haxe.http.HttpStatus;
 import haxe.http.HttpMethod;
 import weblink._internal.Mime;
@@ -13,6 +14,11 @@ class Weblink {
 	public var server:Server;
 	public var routes:Map<String, Map<String, Array<Func>>> = [];
 
+	//Anonymous and redefinable function for 404 errors.
+	public var fnRouteNotFound(null,set):Func = function(request:Request, response:Response):Void{
+		response.status = 404;
+		response.send("Error 404, Route Not found.");
+	}
 	var _serve:Bool = false;
 	var _path:String;
 	var _dir:String;
@@ -71,10 +77,7 @@ class Weblink {
 	}
 
 
-	public function returnNotFound(request:Request, response:Response){
-		response.status = 404;
-		response.send("Error 404, Route Not found.");
-	}
+
 	
 	private function _getEvent(request:Request, response:Response) {
 		if (_serve && response.status == OK && request.path.indexOf(_path) == 0) {
@@ -85,7 +88,7 @@ class Weblink {
 		if(this.routes.exists(request.path)){
 			routeList = this.routes[request.path].get("GET");
 		} else { // Don't have the route, don't process it and escape.
-			returnNotFound(request, response);
+			this.fnRouteNotFound(request, response);
 			return;
 		}
 
@@ -131,5 +134,10 @@ class Weblink {
 	private inline function _headEvent(request:Request, response:Response) {
 		var route = this.routes[request.path];
 		route.get("HEAD")[0](request, response);
+	}
+
+	public function set_fnRouteNotFound(value:Func):Func {
+		this.fnRouteNotFound = value;
+		return this.fnRouteNotFound;
 	}
 }

--- a/weblink/Weblink.hx
+++ b/weblink/Weblink.hx
@@ -1,5 +1,6 @@
 package weblink;
 
+import haxe.http.HttpStatus;
 import haxe.http.HttpMethod;
 import weblink._internal.Mime;
 import weblink._internal.Server;
@@ -69,12 +70,25 @@ class Weblink {
 		route.get("PUT")[0](request, response);
 	}
 
+
+	public function returnNotFound(request:Request, response:Response){
+		response.status = 404;
+		response.send("Error 404, Route Not found.");
+	}
+	
 	private function _getEvent(request:Request, response:Response) {
 		if (_serve && response.status == OK && request.path.indexOf(_path) == 0) {
 			if (_serveEvent(request, response))
 				return;
 		}
-		var routeList = this.routes[request.path].get("GET");
+		var routeList = [];
+		if(this.routes.exists(request.path)){
+			routeList = this.routes[request.path].get("GET");
+		} else { // Don't have the route, don't process it and escape.
+			returnNotFound(request, response);
+			return;
+		}
+
 		var get = routeList[0];
 		var middleware = routeList[1];
 		if (middleware != null)

--- a/weblink/Weblink.hx
+++ b/weblink/Weblink.hx
@@ -1,5 +1,8 @@
 package weblink;
 
+import haxe.http.HttpStatus;
+import haxe.http.HttpMethod;
+import weblink._internal.Mime;
 import weblink._internal.Server;
 
 using haxe.io.Path;
@@ -10,8 +13,11 @@ class Weblink {
 	public var server:Server;
 	public var routes:Map<String, Map<String, Array<Func>>> = [];
 
-	//Anonymous and redefinable function for 404 errors.
-	public var fnRouteNotFound(null,set):Func = function(request:Request, response:Response):Void{
+	/**
+	Default anonymous function defining the behavior should a requested route not exist.
+	Suggested that application implementers use set_pathNotFound() to define custom 404 status behavior/pages
+	**/
+	public var pathNotFound(null,set):Func = function(request:Request, response:Response):Void{
 		response.status = 404;
 		response.send("Error 404, Route Not found.");
 	}
@@ -84,7 +90,7 @@ class Weblink {
 		if(this.routes.exists(request.path)){
 			routeList = this.routes[request.path].get("GET");
 		} else { // Don't have the route, don't process it and escape.
-			this.fnRouteNotFound(request, response);
+			this.pathNotFound(request, response);
 			return;
 		}
 
@@ -132,8 +138,8 @@ class Weblink {
 		route.get("HEAD")[0](request, response);
 	}
 
-	public function set_fnRouteNotFound(value:Func):Func {
-		this.fnRouteNotFound = value;
-		return this.fnRouteNotFound;
+	public function set_pathNotFound(value:Func):Func {
+		this.pathNotFound = value;
+		return this.pathNotFound;
 	}
 }

--- a/weblink/Weblink.hx
+++ b/weblink/Weblink.hx
@@ -1,9 +1,5 @@
 package weblink;
 
-import haxe.Constraints.Function;
-import haxe.http.HttpStatus;
-import haxe.http.HttpMethod;
-import weblink._internal.Mime;
 import weblink._internal.Server;
 
 using haxe.io.Path;


### PR DESCRIPTION
Create a default 404 response to requests for routes that do not exist.

Implementation provides a setter within the Weblink class that allows an individual developer to define an application specific response following the Func type definition if desired.

As well added a test to Path for this... as well as demonstrate the 404 override by simply taking the implementation and replacing the default one, this could probably be subtracted.