### PR TITLE
Add route-independent middleware

### DIFF
--- a/tests/Test.hx
+++ b/tests/Test.hx
@@ -19,6 +19,7 @@ class Test {
 		TestJwks.main();
 		TestJwt.main();
 		TestOAuth2.main();
+		TestMiddlewareShortCircuit.main();
 		TestPath.main();
 		TestPostData.main();
 		TestProjection.main();

--- a/tests/Test.hx
+++ b/tests/Test.hx
@@ -19,6 +19,7 @@ class Test {
 		TestJwks.main();
 		TestJwt.main();
 		TestOAuth2.main();
+		TestMiddlewareCorrectOrder.main();
 		TestMiddlewareShortCircuit.main();
 		TestPath.main();
 		TestPostData.main();

--- a/tests/TestMiddlewareCorrectOrder.hx
+++ b/tests/TestMiddlewareCorrectOrder.hx
@@ -1,0 +1,51 @@
+import haxe.Http;
+import haxe.io.Bytes;
+import sys.thread.Thread;
+import weblink.Weblink;
+
+class TestMiddlewareCorrectOrder {
+	static var v1:String = "";
+	static var v2:String = "";
+	static var v3:String = "";
+
+	public static function main() {
+		trace("Starting Middleware Correct Order Test");
+
+		final app = new Weblink();
+
+		app.use((_, _) -> {
+			v1 = "foo";
+			v2 = "foo";
+			v3 = "foo";
+		});
+
+		app.use((_, _) -> {
+			v1 = "bar";
+			v2 = "bar";
+		});
+
+		app.use((_, _) -> {
+			v1 = "baz";
+		});
+
+		app.get("/", (_, res) -> res.send('$v1$v2$v3'));
+		app.listen(2000, false);
+
+		Thread.create(() -> {
+			final http = new Http("http://localhost:2000");
+			var response:Null<Bytes> = null;
+			http.onBytes = bytes -> response = bytes;
+			http.onError = e -> throw e;
+			http.request(false);
+			if (response.toString() != "bazbarfoo")
+				throw "not the response we expected";
+			app.close();
+		});
+
+		while (app.server.running) {
+			app.server.update(false);
+			Sys.sleep(0.2);
+		}
+		trace("done");
+	}
+}

--- a/tests/TestMiddlewareShortCircuit.hx
+++ b/tests/TestMiddlewareShortCircuit.hx
@@ -1,0 +1,34 @@
+// For a middleware that does not cut the request short, see TestCompression.
+import haxe.Http;
+import haxe.io.Bytes;
+import sys.thread.Thread;
+import weblink.Weblink;
+
+class TestMiddlewareShortCircuit {
+	public static function main() {
+		trace("Starting Middleware Short Circuit Test");
+
+		final app = new Weblink();
+		app.get("/", (_, _) -> throw "should not be called", next -> {
+			return (_, res) -> res.send("foo");
+		});
+		app.listen(2000, false);
+
+		Thread.create(() -> {
+			final http = new Http("http://localhost:2000");
+			var response:Null<Bytes> = null;
+			http.onBytes = bytes -> response = bytes;
+			http.onError = e -> throw e;
+			http.request(false);
+			if (response.toString() != "foo")
+				throw "not the response we expected";
+			app.close();
+		});
+
+		while (app.server.running) {
+			app.server.update(false);
+			Sys.sleep(0.2);
+		}
+		trace("done");
+	}
+}

--- a/weblink/Handler.hx
+++ b/weblink/Handler.hx
@@ -1,0 +1,14 @@
+package weblink;
+
+/**
+	A Handler is a function that operates on an incoming HTTP request.
+
+	Example of a simple Handler:
+
+	```haxe
+	function handler(request:Request, response:Response) {
+		response.send("Hello world!");
+	}
+	```
+**/
+typedef Handler = (request:Request, response:Response) -> Void;

--- a/weblink/Weblink.hx
+++ b/weblink/Weblink.hx
@@ -1,6 +1,7 @@
 package weblink;
 
 import haxe.http.HttpMethod;
+import weblink.Handler;
 import weblink._internal.Server;
 import weblink._internal.ds.RadixTree;
 import weblink.security.CredentialsProvider;
@@ -9,17 +10,15 @@ import weblink.security.OAuth.OAuthEndpoints;
 
 using haxe.io.Path;
 
-private typedef Func = (request:Request, response:Response) -> Void;
-
 class Weblink {
 	public var server:Server;
-	public var routeTree:RadixTree<Func>;
+	public var routeTree:RadixTree<Handler>;
 
 	/**
 		Default anonymous function defining the behavior should a requested route not exist.
 		Suggested that application implementers use set_pathNotFound() to define custom 404 status behavior/pages
 	**/
-	public var pathNotFound(null, set):Func = function(request:Request, response:Response):Void {
+	public var pathNotFound(null, set):Handler = function(request:Request, response:Response):Void {
 		response.status = 404;
 		response.send("Error 404, Route Not found.");
 	}
@@ -33,11 +32,11 @@ class Weblink {
 		this.routeTree = new RadixTree();
 	}
 
-	private function _updateRoute(path:String, method:HttpMethod, handler:Func) {
+	private function _updateRoute(path:String, method:HttpMethod, handler:Handler) {
 		this.routeTree.put(path, method, handler);
 	}
 
-	public function get(path:String, func:Func, ?middleware:Func) {
+	public function get(path:String, func:Handler, ?middleware:Handler) {
 		if (middleware != null) {
 			final oldFunc = func;
 			func = (req, res) -> {
@@ -48,15 +47,15 @@ class Weblink {
 		_updateRoute(path, Get, func);
 	}
 
-	public function post(path:String, func:Func) {
+	public function post(path:String, func:Handler) {
 		_updateRoute(path, Post, func);
 	}
 
-	public function put(path:String, func:Func) {
+	public function put(path:String, func:Handler) {
 		_updateRoute(path, Put, func);
 	}
 
-	public function head(path:String, func:Func) {
+	public function head(path:String, func:Handler) {
 		_updateRoute(path, Head, func);
 	}
 
@@ -129,7 +128,7 @@ class Weblink {
 		}
 	}
 
-	public function set_pathNotFound(value:Func):Func {
+	public function set_pathNotFound(value:Handler):Handler {
 		this.pathNotFound = value;
 		return this.pathNotFound;
 	}

--- a/weblink/Weblink.hx
+++ b/weblink/Weblink.hx
@@ -4,6 +4,7 @@ import haxe.http.HttpMethod;
 import weblink.Handler;
 import weblink._internal.Server;
 import weblink._internal.ds.RadixTree;
+import weblink.middleware.Middleware;
 import weblink.security.CredentialsProvider;
 import weblink.security.Jwks;
 import weblink.security.OAuth.OAuthEndpoints;
@@ -36,13 +37,9 @@ class Weblink {
 		this.routeTree.put(path, method, handler);
 	}
 
-	public function get(path:String, func:Handler, ?middleware:Handler) {
+	public function get(path:String, func:Handler, ?middleware:Middleware) {
 		if (middleware != null) {
-			final oldFunc = func;
-			func = (req, res) -> {
-				middleware(req, res);
-				oldFunc(req, res);
-			};
+			func = middleware(func);
 		}
 		_updateRoute(path, Get, func);
 	}

--- a/weblink/_internal/ds/RadixTree.hx
+++ b/weblink/_internal/ds/RadixTree.hx
@@ -10,7 +10,7 @@ using StringTools;
 	A modified version of a radix tree, suitable for HTTP request routing.
 
 	Note: This class is generic to make testing easier.
-	Out of testing, the T parameter will always be weblink.Func.
+	Out of testing, the T parameter will always be weblink.Handler.
 **/
 class RadixTree<T> {
 	public var root:Node<T>;
@@ -73,7 +73,7 @@ enum Edge {
 	as it stores a reference to its parent.
 
 	Note: This class is generic to make testing easier.
-	Out of testing, the T parameter will always be weblink.Func.
+	Out of testing, the T parameter will always be weblink.Handler.
 **/
 @:allow(weblink._internal.ds.RadixTree)
 final class Node<T> {

--- a/weblink/middleware/Middleware.hx
+++ b/weblink/middleware/Middleware.hx
@@ -1,0 +1,87 @@
+package weblink.middleware;
+
+import weblink.Handler;
+
+private typedef MiddlewareFunc = (next:Handler) -> Handler;
+
+/**
+	Middleware is a piece of code that acts on the HTTP request
+	before your route handler does.
+
+	A Middleware can be one of two things:
+
+	- A Handler. This is a function that takes a request and a response, and always succeeds.
+	  Behind the scenes, Weblink makes sure it always calls the next handler.
+
+	  Example:
+
+	  ```haxe
+	  function myLoggingMiddleware(request:Request, response:Response) {
+		  trace('${request.method} ${request.path}');
+	  }
+	  ```
+
+	- A function that takes a Handler and returns another Handler.
+	  This new Handler can then decide for itself
+	  whether to short-circuit or to continue the request.
+
+	  Example:
+
+	  ```haxe
+	  function myAuthMiddleware(next:Handler): Handler {
+		  final credentials = Base64.encode(Bytes.ofString("admin:1234"));
+		  return (request:Request, response:Response) -> {
+			  if (request.headers.get("Authorization") == "Basic " + credentials) {
+				  next(request, response);
+			  } else {
+				  response.status = Unauthorized;
+				  response.headers = new List();
+				  response.headers.add({key: "WWW-Authenticate", value: 'Basic realm="Cool Site"'});
+				  response.send("Sorry, cannot let you in!");
+			  }
+		  };
+	  }
+	  ```
+
+	Invoke a Middleware object to chain handlers, like this:
+
+	```haxe
+	handler = middleware(handler); // same type
+	```
+
+	If you have multiple middlewares to chain, remember it is right-associative:
+
+	```haxe
+	handler = first(second(third(fourth(handler))));
+	```
+
+	This specific implemention is inspired by many routers in the Golang ecosystem.
+**/
+@:callable
+abstract Middleware(MiddlewareFunc) {
+	private inline function new(func:MiddlewareFunc) {
+		this = func;
+	}
+
+	/**
+		Creates a new middleware from a function that folds the handlers.
+		That function has the ability to short-circuit.
+	**/
+	@:from
+	private static inline function fromFolding(func:MiddlewareFunc):Middleware {
+		return new Middleware(func);
+	}
+
+	/**
+		Creates a new middleware from a function that always falls through, to the next handler.
+	**/
+	@:from
+	private static inline function fromHandler(func:Handler):Middleware {
+		return new Middleware(next -> {
+			return (req, res) -> {
+				func(req, res);
+				next(req, res);
+			};
+		});
+	}
+}


### PR DESCRIPTION
As you've mentioned previously, I'm back with some changes to middleware :smile: 

## Global middleware

The router (app; ```weblink.Weblink```) can now ```use``` middleware. This means it will be applied to all registered routes, including the fallback ```.pathNotFound``` handler.

For example, this code will log every hit request:

```haxe
function main() {
	final app = new weblink.Weblink();
	app.use((req, _) -> trace('${req.method} ${req.path}'));
	app.get("/", (_, res) -> res.send("I'm an index!"));
	app.get("/blog", (_, res) -> res.send("I'm a blog!"));
	app.listen(2000);
}
```
```
> haxe example.hxml && hl example.hl
Example.hx:3: GET /
Example.hx:3: GET /blog
Example.hx:3: GET /somethingelse
```

## Middleware that can decide whether to continue handling the request

Introduced another form of Middleware! This time, it can take a Handler that is next in the chain. It can then decide whether to progress the request by calling that handler, or to short-circuit and return some error message.

Example:

```haxe
app.use(next -> (req, res) -> {
	if (req.headers.get("X-Super-Secret-Header") != "Secret-Password") {
		res.send("hi, this is a cool site! we have puppies look~");
	} else {
		next(req, res);
	}
});
app.get("/", (_, res) -> res.send("welcome to Evil Corp Lair! hahaha"));
```

## Chaining middleware

This does not need much explaining: you can ```use``` multiple middlewares in a row and they will be invoked in that specific order.

```haxe
// a fantasy third party library that does not exist
import CollectionOfThirdPartyMiddleware.*;

// ...

app.use(generateUniqueRequestId);
app.use(openTelemetry);
app.use(setCors);
app.use(recoverFromExceptions);
```