### PR TITLE
Fix compression middleware breaking text responses

### DIFF
--- a/weblink/Response.hx
+++ b/weblink/Response.hx
@@ -2,6 +2,7 @@ package weblink;
 
 import haxe.http.HttpStatus;
 import haxe.io.Bytes;
+import haxe.io.Encoding;
 import weblink.Cookie;
 import weblink._internal.HttpStatusMessage;
 import weblink._internal.Server;
@@ -44,10 +45,7 @@ class Response {
 	}
 
 	public inline function send(data:String) {
-		var buff = sendHeaders(data.length);
-		buff.add(data);
-		socket.writeString(buff.toString());
-		end();
+		this.sendBytes(Bytes.ofString(data, Encoding.UTF8));
 	}
 
 	private function end() {


### PR DESCRIPTION
Turns out ```Response.sendBytes``` was calling ```Response.write```, but ```Response.send``` was not.

In this case, this meant text responses would not get affected by compression middleware. However, it would still set the ```Content-Encoding``` header, breaking the website in browsers.

This PR replaces ```send``` implementation with one that calls ```sendBytes```.