### PR TITLE
Do not throw if sending a response to a closed TCP stream

### DIFF
--- a/weblink/_internal/Server.hx
+++ b/weblink/_internal/Server.hx
@@ -107,10 +107,6 @@ class Server extends SocketServer {
 		} while (running && blocking);
 	}
 
-	public inline function closeSocket(socket:Socket) {
-		// sockets.remove(socket);
-		socket.close();
-	}
 	override function close(?callb:() -> Void) {
 		super.close(callb);
 		loop.stop();


### PR DESCRIPTION
The low-hanging fruit of #26.

- Suppresses exceptions when writing to a closed `Socket` (e.g. when the client has disconnected).
- You still cannot `sendBytes` with an `end`ed `Response`, but the error message should have more sense now.

Still have no idea about that libuv crash? Will try to investigate later