### PR TITLE
Fix persistent (keep-alive) connections

### DIFF
--- a/weblink/Response.hx
+++ b/weblink/Response.hx
@@ -20,7 +20,7 @@ class Response {
 
 	var socket:Null<Socket>;
 	var server:Null<Server>;
-	var close:Bool = true;
+	var close:Bool = false; // default in HTTP/1.1
 
 	private function new(socket:Socket, server:Server) {
 		this.socket = socket;


### PR DESCRIPTION
Weblink currently closes persistent ("keep-alive") connections when the client tries to reuse them, which is kind of against the point of persistent connections.

As an example, the following application:
```haxe
function main() {
	final app = new weblink.Weblink();
	app.get("/", (_, res) -> res.send("Hello World!"));
	app.listen(2037, true);
}
```
can be interacted with using curl:
```sh
curl -v -H "Connection: keep-alive" http://localhost:2037/ http://localhost:2037/
```
(some output lines omitted)
```
* Connection #0 to host localhost left intact
* Re-using existing connection with host localhost
* Connection died, retrying a fresh connect (retry count: 1)
* shutting down connection #0
* Issue another request to this URL: 'http://localhost:2037/'
* Connection #1 to host localhost left intact
```
<details>
<summary>Some clients, like node's fetch, do not try to reestablish the connection at all.</summary>

```
Uncaught TypeError: fetch failed
    at node:internal/deps/undici/undici:13185:13
    at async REPL14:1:40 {
  [cause]: SocketError: other side closed
```

(NB: Node error does not occur on `master` because Weblink cannot find the "Connection" header, uppercase C. See #34)
</details>

When this patch is applied, the same curl command results in: (some lines omitted)
```
* Connection #0 to host localhost left intact
* Re-using existing connection with host localhost
* Connection #0 to host localhost left intact
```
"Connection: close" still works as well:
```
* shutting down connection #0
* shutting down connection #1
```