### PR TITLE
Change server update loop from NoWait to Default

### DIFF
--- a/weblink/_internal/Server.hx
+++ b/weblink/_internal/Server.hx
@@ -103,7 +103,7 @@ class Server extends SocketServer {
 	public function update(blocking:Bool = true) {
 		do {
 			@:privateAccess MainLoop.tick(); // for timers
-			loop.run(NoWait);
+			loop.run(Default);
 		} while (running && blocking);
 	}
 


### PR DESCRIPTION
Change reduces idle CPU usage by a large amount. (100% to 0%)

Needs testing.

I have confirmed only that POST and GET requests with plain text still work.