### PR TITLE
Add middleware for catching exceptions

### DIFF
--- a/weblink/HTTPException.hx
+++ b/weblink/HTTPException.hx
@@ -1,3 +1,4 @@
 package weblink;
 
+@:deprecated("Use weblink.exceptions.HttpException instead")
 class HTTPException extends haxe.Exception {}

--- a/weblink/exceptions/HttpException.hx
+++ b/weblink/exceptions/HttpException.hx
@@ -1,0 +1,27 @@
+package weblink.exceptions;
+
+import haxe.Exception;
+import haxe.http.HttpStatus;
+import weblink._internal.HttpStatusMessage;
+
+/**
+	A base class for exceptions that occurred when handling HTTP requests.
+**/
+@:nullSafety(StrictThreaded)
+class HttpException extends Exception {
+	/**
+		The HTTP status code that is associated with this exception.
+	**/
+	public var statusCode(default, null):HttpStatus;
+
+	/**
+		Creates a new HttpException instance.
+		@param statusCode (Recommended) The HTTP status code that is associated with this exception.
+		@param message (Optional) The message of this exception.
+		@param previous (Optional) The previous exception that caused this exception.
+	**/
+	public function new(statusCode:HttpStatus = InternalServerError, ?message:String, ?previous:Exception) {
+		super(message != null ? message : HttpStatusMessage.fromCode(statusCode), previous, null);
+		this.statusCode = statusCode;
+	}
+}

--- a/weblink/middleware/DefaultMiddleware.hx
+++ b/weblink/middleware/DefaultMiddleware.hx
@@ -1,0 +1,83 @@
+package weblink.middleware;
+
+import haxe.Exception;
+import haxe.http.HttpStatus;
+import weblink.Handler;
+import weblink.Request;
+import weblink.Response;
+import weblink._internal.HttpStatusMessage;
+import weblink.exceptions.HttpException;
+
+/**
+	A collection of standard middlewares.
+**/
+@:nullSafety(StrictThreaded)
+final class DefaultMiddleware {
+	private function new() {}
+
+	/**
+		Creates a middleware that recovers from exceptions called down the chain.
+
+		If an exception is caught, the response will try to be sent
+		with the appropriate status code and message.
+		@param configure (Optional) A function that can be used to configure the middleware.
+	**/
+	public static function recoverFromExceptions(?configure:(options:RecoverOptions) -> Void):Middleware {
+		final options = RecoverOptions.defaults();
+		if (configure != null) {
+			configure(options);
+		}
+
+		return (next:Handler) -> {
+			return (request:Request, response:Response) -> {
+				try {
+					next(request, response);
+				} catch (e:Exception) {
+					final ex:Null<HttpException> = Std.downcast(e, HttpException);
+					final status:HttpStatus = ex != null ? ex.statusCode : InternalServerError;
+					final statusMessage = HttpStatusMessage.fromCode(status);
+					if (options.log) {
+						trace(e.details());
+					}
+					try {
+						response.status = status;
+						response.contentType = "text/plain";
+						if (options.includeStackTrace) {
+							response.send('$statusMessage\n\n${e.details()}');
+						} else {
+							response.send(statusMessage);
+						}
+					} catch (_) {
+						// Either parts or the entire response might have been already sent
+						final client = @:privateAccess response.socket;
+						if (client != null) {
+							client.close(); // try to close if not closed already
+						}
+					}
+				}
+			};
+		};
+	}
+}
+
+@:structInit
+private final class RecoverOptions {
+	/**
+		Should the exception response include a stack trace? Defaults to `false`.
+
+		This should be set to `false` in production deployments.
+	**/
+	public var includeStackTrace:Bool;
+
+	/**
+		Should the exception be `trace()`d? Defaults to `false`.
+	**/
+	public var log:Bool;
+
+	public static function defaults():RecoverOptions {
+		return {
+			includeStackTrace: false,
+			log: false,
+		};
+	}
+}

--- a/weblink/security/OAuth.hx
+++ b/weblink/security/OAuth.hx
@@ -1,6 +1,6 @@
 package weblink.security;
 
-import weblink.HTTPException;
+import weblink.exceptions.HttpException;
 import weblink.security.BCryptPassword;
 import weblink.security.Jwt;
 import weblink.security.OAuth2PasswordBearer;
@@ -64,7 +64,7 @@ class OAuth {
 	}
 
 	private function get_current_user(token:String):UserInDB {
-		var credentials_exception = new HTTPException('401 Could not validate credentials {"WWW-Authenticate": "Bearer"}');
+		var credentials_exception = new HttpException(401, 'Could not validate credentials {"WWW-Authenticate": "Bearer"}');
 		var token_data;
 		try {
 			var payload = Jwt.decode(token, this.secret_key, ALGORITHM);
@@ -86,11 +86,11 @@ class OAuth {
 	public function get_current_active_user(request):User {
 		var token = this.oauth2_scheme.call(request);
 		if (token == null) {
-			throw new HTTPException('401 Bad Token {"WWW-Authenticate": "Bearer"}');
+			throw new HttpException(401, 'Bad Token {"WWW-Authenticate": "Bearer"}');
 		}
 		var current_user:UserInDB = this.get_current_user(token);
 		if (current_user.disabled) {
-			throw new HTTPException("400 Inactive user");
+			throw new HttpException(400, "Inactive user");
 		}
 		// We don't want to return hashed_password for security reasons
 		return Projection.convert(current_user, User);
@@ -153,7 +153,7 @@ class OAuthEndpoints {
 		var form_data = OAuth2PasswordRequestForm.validate(data);
 		var user = this.oAuth.authenticate_user(form_data.username, form_data.password);
 		if (user == null) {
-			throw new HTTPException('401 Incorrect username or password {"WWW-Authenticate": "Bearer"}');
+			throw new HttpException(401, 'Incorrect username or password {"WWW-Authenticate": "Bearer"}');
 		}
 		return Jwt.create_access_token({sub: user.username}, this.oAuth.secret_key, OAuth.ALGORITHM, ACCESS_TOKEN_EXPIRE_MINUTES);
 	}

--- a/weblink/security/OAuth2PasswordBearer.hx
+++ b/weblink/security/OAuth2PasswordBearer.hx
@@ -1,6 +1,6 @@
 package weblink.security;
 
-import weblink.HTTPException;
+import weblink.exceptions.HttpException;
 
 class OAuth2 {
 	var scheme_name:Null<String>;
@@ -15,7 +15,7 @@ class OAuth2 {
 		var authorization:String = request.headers.get("Authorization");
 		if (authorization == null) {
 			if (this.auth_error) {
-				throw new HTTPException("403 Not authenticated");
+				throw new HttpException(403, "Not authenticated");
 			} else {
 				return null;
 			}
@@ -43,7 +43,7 @@ class OAuth2PasswordBearer extends OAuth2 {
 		var param = authSplit[1];
 		if (authorization == null || scheme.toLowerCase() != "bearer") {
 			if (this.auth_error) {
-				throw new HTTPException('401 Not authenticated {"WWW-Authenticate": "Bearer"}');
+				throw new HttpException(401, 'Not authenticated {"WWW-Authenticate": "Bearer"}');
 			} else {
 				return null;
 			}


### PR DESCRIPTION
Currently, throwing exceptions inside HTTP handlers (`.get()` etc.) crashes the server.

This PR introduces OPTIONAL, included middleware that translates thrown exceptions into proper HTTP responses. Additionally, `weblink.HTTPException` was superseded by one with an explicit status code field.

Example usage:
```haxe
import weblink.Weblink;
import weblink.exceptions.HttpException;
import weblink.middleware.DefaultMiddleware;

function main() {
	final app = new Weblink();
	app.use(DefaultMiddleware.recoverFromExceptions());
	app.get("/", (_, _) -> throw new HttpException(ImATeapot, "Hello World!"));
	app.listen(2000, true);
}

```
```
➜ curl -i http://localhost:2000/

HTTP/1.1 418 I'm a teapot
Connection: keep-alive
Content-type: text/plain
Content-length: 12

I'm a teapot%
```
Additionally, non-production deployments can be configured to include stack traces in the responses:
```diff
- 	app.use(DefaultMiddleware.recoverFromExceptions());
+	app.use(DefaultMiddleware.recoverFromExceptions(options -> {
+		options.includeStackTrace = true;
+	}));
```
```
➜ curl -i http://localhost:2000/

HTTP/1.1 418 I'm a teapot
Connection: keep-alive
Content-type: text/plain
Content-length: 715

I'm a teapot

Exception: Hello World!
Called from _Example.$Example_Fields_.~main.1 (Example.hx line 10)
Called from local function #693 (weblink/middleware/DefaultMiddleware.hx line 34)
Called from weblink._internal.Server.complete (weblink/_internal/Server.hx line 87)
Called from local function #675 (weblink/_internal/Server.hx line 38)
Called from hl.uv.Stream.~readStart.0 (/usr/share/haxe/std/hl/uv/Stream.hx line 42)
Called from haxe.$MainLoop.tick (/usr/share/haxe/std/haxe/MainLoop.hx line 179)
Called from weblink._internal.Server.update (weblink/_internal/Server.hx line 101)
Called from weblink.Weblink.listen (weblink/Weblink.hx line 89)
Called from _Example.$Example_Fields_.main (Example.hx line 11)%
```